### PR TITLE
Try to use TLS connection

### DIFF
--- a/config/postfix/main.cf
+++ b/config/postfix/main.cf
@@ -23,6 +23,10 @@ smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
 smtpd_use_tls=yes
 smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
 smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
+smtpd_tls_security_level = may
+smtp_tls_security_level = may
+smtp_tls_loglevel = 1
+smtpd_tls_loglevel = 1
 
 # See /usr/share/doc/postfix/TLS_README.gz in the postfix-doc package for
 # information on enabling SSL in the smtp client.


### PR DESCRIPTION
Fixes red padlock in gmail (https://gmail.googleblog.com/2016/02/making-email-safer-for-you-posted-by.html)
